### PR TITLE
Restored compatibility after Joint.None was removed.

### DIFF
--- a/src/panda_robot/utils/kdl_parser.py
+++ b/src/panda_robot/utils/kdl_parser.py
@@ -58,7 +58,7 @@ def urdf_pose_to_kdl_frame(pose):
 def urdf_joint_to_kdl_joint(jnt):
     origin_frame = urdf_pose_to_kdl_frame(jnt.origin)
     if jnt.joint_type == 'fixed':
-        return kdl.Joint(jnt.name, getattr(kdl.Joint,"None"))
+        return kdl.Joint(jnt.name, getattr(kdl.Joint, 'Fixed') if hasattr(kdl.Joint, 'Fixed') else getattr(kdl.Joint, 'None'))
     axis = kdl.Vector(*[float(s) for s in jnt.axis])
     if jnt.joint_type == 'revolute':
         return kdl.Joint(jnt.name, origin_frame.p,
@@ -70,7 +70,7 @@ def urdf_joint_to_kdl_joint(jnt):
         return kdl.Joint(jnt.name, origin_frame.p,
                          origin_frame.M * axis, kdl.Joint.TransAxis)
     print("Unknown joint type: %s." % jnt.joint_type)
-    return kdl.Joint(jnt.name, getattr(kdl.Joint,"None"))
+    return kdl.Joint(jnt.name, getattr(kdl.Joint, 'Fixed') if hasattr(kdl.Joint, 'Fixed') else getattr(kdl.Joint, 'None'))
 
 def urdf_inertial_to_kdl_rbi(i):
     origin = urdf_pose_to_kdl_frame(i.origin)


### PR DESCRIPTION
Similar to:
https://github.com/ros/kdl_parser/pull/45
https://github.com/ros/kdl_parser/issues/44

When migrating to 20.04/Noetic/Python3 I ran into the same `AttributeError: type object 'PyKDL.Joint' has no attribute 'None'` error.  

This is pretty much just a copy of their fix.